### PR TITLE
Autorouter RFC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ validate*.json
 .idea
 
 .vscode
+.game-corpus
+.minimal_corpus
+output.json
+output_off_by_one_in_action_id.json
+output*

--- a/Rakefile
+++ b/Rakefile
@@ -98,6 +98,13 @@ task 'annotate' do
   Sequel::Annotate.annotate(Dir['models/*.rb'])
 end
 
+desc 'Precompile assets for me'
+task :precompile_me do
+  require_relative 'lib/assets'
+  assets = Assets.new(cache: true, compress: false, gzip: false)
+  assets.combine(:all)
+end
+
 desc 'Precompile assets for production'
 task :precompile do
   require_relative 'lib/assets'

--- a/analyze.js
+++ b/analyze.js
@@ -1,0 +1,80 @@
+const fs = require('node:fs');
+
+snabbdom = {
+    init: function() {}
+}
+
+Big = require('./public/assets/server.js').Big
+
+games = {}
+game_id_to_title = {}
+
+let output = JSON.parse(fs.readFileSync('output.json', 'utf8'))
+
+for (let game_file of process.argv.slice(2)) {
+    let game_data_str = fs.readFileSync(game_file, 'utf8')
+    let game_data;
+    try {
+      game_data = JSON.parse(game_data_str)
+    } catch (e) {
+      console.log("failed to parse", game_file);
+      continue;
+    }
+    if (game_data["error"]) continue;
+
+    let title = game_data["title"]
+    if (!games[title]) {
+        games[title] = {
+          auto_win: 0,
+          auto_lose: 0,
+          equal: 0,
+        }
+    }
+
+    let undone_ids = get_undone_ids(game_data)
+    for (let action of game_data["actions"]) {
+        if (action["type"] != "run_routes") continue;
+        if (undone_ids.has(action["id"])) continue;
+        if (!output[game_data["id"]+':'+action["id"]]) continue;
+        if (output[game_data["id"]+':'+action["id"]].revenue == "UNDO") continue;
+        if (output[game_data["id"]+':'+action["id"]].time_seconds > 60) continue;
+        let hand_revenue = action["routes"].map((r)=>r.revenue).reduce((b, a) => b + a, 0)
+        let auto_revenue = output[game_data["id"]+':'+action["id"]].revenue
+            if (title == "1846" && output[game_data["id"]+':'+action["id"]].time_seconds > 5) console.log(game_data["id"]+':'+action["id"])
+        if (auto_revenue > hand_revenue) {
+            games[title].auto_win += 1
+        } else if (auto_revenue == hand_revenue) {
+            games[title].equal += 1
+        } else {
+            games[title].auto_lose += 1
+        }
+    }
+}
+
+// todo off by one still feels right, test this
+function get_undone_ids(game_data) {
+    let undo_blocks = []
+    let last_valid_id = -1;
+    game_data["actions"].forEach((action, index) => {
+        if (action["type"] == "undo") {
+          if (action["action_id"]) {
+              undo_blocks.push([action["action_id"] + 1, action["id"]]);
+              last_valid_id = action["action_id"];
+          } else {
+              undo_blocks.push([last_valid_id, last_valid_id]);
+              last_valid_id -= 1;
+          }
+        } else if (action["type"] == "redo") {
+          undo_blocks.pop()[1]
+          last_valid_id = action["id"]
+        } else {
+          last_valid_id = action["id"]
+        }
+    });
+    return new Set(undo_blocks.flatMap((e) => { return new Array(e[1] - e[0]).fill(1).map( (_, i) => i+e[0] )}))
+}
+
+console.log(games)
+
+console.log("autorouter is good enough", Object.entries(games).filter((x) => x[1].auto_lose == 0).map((x) => x[0]))
+console.log("autorouter isn't good enough", Object.entries(games).filter((x) => x[1].auto_lose != 0).map((x) => x[0]))

--- a/autorouter.mjs
+++ b/autorouter.mjs
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import process from 'node:process';
+import { execFile} from 'node:child_process';
+
+let output_file = 'output.json';
+
+let output = load_output(output_file);
+let count = 0;
+let number_running = 0;
+
+async function main() {
+  let target_count = process.argv.length - 2;
+  let current_count = 0;
+  for (let game_file of process.argv.slice(2)) {
+    await run(game_file);
+    current_count += 1;
+    console.log(current_count, target_count);
+  }
+}
+await main();
+while (number_running != 0) {
+  await sleep(100)
+}
+write_output(output_file);
+
+async function run(game_file) {
+    let game_data_str = fs.readFileSync(game_file, 'utf8')
+    let game_data = JSON.parse(game_data_str)
+    if (game_data["error"]) return;
+
+    for (let action of game_data["actions"]) {
+        if (action["type"] != "run_routes") continue;
+        if (output[game_data["id"]+':'+action["id"]]) continue;
+        while (number_running == 2) await sleep(100)
+        number_running += 1
+        execFile('node', ['./autorouter_single.js', game_file, action["id"] + ""], {
+            stdio: 'pipe',
+            // todo: using this makes it so we can't detect what happened timeout: 0,
+
+            // Use utf8 encoding for stdio pipes
+            encoding: 'utf8',
+        }, (error, stdout, stderr) => {
+            number_running -= 1;
+            try {
+                output[game_data["id"]+':'+action["id"]] = JSON.parse(stdout.match(new RegExp('output:(.*)'))[1])
+            } catch (e) {
+                console.log("failed to run", game_data["id"]+':'+action["id"])
+                output[game_data["id"]+':'+action["id"]] = {revenue: "DNR"}
+            }
+            let number_keys = Object.keys(output).length;
+            if (count + 10 < number_keys) {
+              write_output(output_file);
+              count = number_keys;
+            }
+        })
+    }
+}
+
+function load_output(file) {
+    return JSON.parse(fs.readFileSync(file, 'utf8'))
+}
+
+function write_output(file) {
+    return fs.writeFileSync(file, JSON.stringify(output))
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/autorouter_single.js
+++ b/autorouter_single.js
@@ -1,0 +1,56 @@
+const fs = require('node:fs');
+const process = require('node:process');
+
+snabbdom = {
+    init: function() {}
+}
+
+Big = require('./public/assets/server.js').Big
+Opal.config.enable_stack_trace = false
+game_data_str = fs.readFileSync(process.argv[2], 'utf8')
+game_data = JSON.parse(game_data_str)
+if (game_data["error"]) return;
+
+title = game_data["title"]
+get_games_to_load(title)
+
+
+//console.log(game_data["actions"])
+
+let target_action = process.argv[3];
+game = Opal.Engine.Game.$load(game_data_str, new Map([["at_action", target_action - 1]]))
+//process.stdout.write(JSON.stringify(Opal.Engine.Game));
+let filtered_actions = game.filtered_actions
+console.log()
+if (!filtered_actions.find((a) => { if (a instanceof Map) { return a.get("id") == target_action}})) {
+    process.stdout.write("output:"+JSON.stringify({revenue: "UNDO"})+"\n")
+    return
+}
+
+router = Opal.Engine.AutoRouter.$new(game)
+let start  = process.hrtime()
+try {
+let routes = router.$compute(game.$current_entity(), new Map([
+    ['routes', []],
+    ["path_timeout", 100],
+    ["route_timeout", 100],
+    ["route_limit", 100000],
+]))
+   routes.forEach((route) => route["$clear_cache!"](new Map([["only_routes", true]])))
+   revenue = game.$routes_revenue(routes)
+   console.log(routes.map((r)=>r.$revenue_str()))
+} catch (e) {
+   console.log(e)
+   revenue = "DNF";
+}
+let time = process.hrtime(start)
+
+process.stdout.write("output:"+JSON.stringify({revenue, hexside_bits: router.next_hexside_bit, time_seconds: time[0]})+"\n")
+
+function get_games_to_load(title) {
+  if (!title) return []
+  game_meta = Opal.Engine.$meta_by_title(title)
+  Opal.top.$require_tree("engine/game/"+game_meta.$fs_name())
+  Opal.top.$require("engine/game/"+game_meta.$fs_name())
+  get_games_to_load(game_meta.DEPENDS_ON)
+}

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -83,7 +83,7 @@ module Engine
           last_right = nil
 
           complete = lambda do
-            chains << { nodes: [left, right], paths: chain }
+            chains << { nodes: [left, right], paths: chain, hexes: chain.map(&:hex) }
             last_left = left
             last_right = right
             left, right = nil

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -86,6 +86,7 @@ module Engine
       static = opts[:routes] || []
       path_timeout = opts[:path_timeout] || 30
       route_limit = opts[:route_limit] || 10_000
+      path_debugger = opts[:path_debugger] || lambda { }
 
       connections = {}
 
@@ -203,8 +204,11 @@ module Engine
               connection_data: connection.clone,
               bitfield: bitfield_from_connection(connection, hexside_bits),
             )
+
+            %x{ if (!path_debugger("walk", route)) return; }
             route.routes = [route]
             route.revenue(suppress_check_other: true) # defer route-collection checks til later
+            %x{ if (!path_debugger("valid_route", route)) return; }
             train_routes[train] << route
           rescue RouteTooLong
             # ignore for this train, and abort walking this path if ignored for all trains

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -197,7 +197,10 @@ module Engine
               @game,
               @game.phase,
               train,
-              connection_data: connection,
+              # we have to clone to prevent multiple routes having the same connection array.
+              # If we don't clone, then later route.touch_node calls will affect all routes with
+              # the same connection array
+              connection_data: connection.clone,
               bitfield: bitfield_from_connection(connection, hexside_bits),
             )
             route.routes = [route]

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -7,10 +7,55 @@ require_relative 'route'
 
 module Engine
   class AutoRouter
+    attr_accessor :running
+
     def initialize(game, flash = nil)
       @game = game
       @next_hexside_bit = 0
       @flash = flash
+    end
+
+    def compute_new(corporation, **opts)
+      # we don't reverse in the new one since we select trains in reverse order
+      trains = @game.route_trains(corporation).sort_by(&:price)
+      train_routes, path_walk_timed_out = path(trains, corporation, **opts)
+      if path_walk_timed_out
+        @flash&.call('Auto route path walk failed to complete (PATH TIMEOUT)')
+      end
+      new_route(train_routes, **opts)
+    end
+
+    def new_route(trains_to_routes, **opts)
+      callback = opts[:callback]
+      @running = true
+      %x{
+          let start = performance.now()
+          g_update = callback
+          new_autoroute(self, trains_to_routes).then((routes) => {
+            // Fix up the revenue calculations since routes revenue can be
+            // impacted by each other
+            self.$real_revenue(routes)
+            self.running = false
+            console.log("AutoRouter took " + (performance.now() - start) + "ms")
+            callback(routes);
+          }).catch((e) => {
+            self.flash("Auto route selection failed to complete (" + e + ")");
+            console.log(e);
+            self.running = false;
+            callback([]);
+          });
+        }
+    end
+
+    def real_revenue(routes)
+      routes.each do |route|
+        route.clear_cache!(only_revenue: true)
+        route.routes = routes
+        route.revenue
+      end
+      @game.routes_revenue(routes)
+    rescue Exception
+      -1
     end
 
     def compute(corporation, **opts)
@@ -25,16 +70,21 @@ module Engine
 
       routes = opts.delete(:routes)
 
-      train_groups.flat_map do |train_group|
+      final_routes = train_groups.flat_map do |train_group|
         opts[:routes] = routes.select { |r| train_group.include?(r.train) }
         compute_for_train_group(train_group, corporation, **opts)
       end
+
+      # a route's revenue calculation can depend on other routes, so we need to
+      # recalculate revenue for the final set of routes.
+      # This fixes https://github.com/tobymao/18xx/issues/11078 / https://github.com/tobymao/18xx/issues/11036
+      real_revenue final_routes
+      final_routes
     end
 
-    def compute_for_train_group(trains, corporation, **opts)
+    def path(trains, corporation, **opts)
       static = opts[:routes] || []
       path_timeout = opts[:path_timeout] || 30
-      route_timeout = opts[:route_timeout] || 10
       route_limit = opts[:route_limit] || 10_000
 
       connections = {}
@@ -181,6 +231,13 @@ module Engine
         train_routes[train] = routes.sort_by(&:revenue).reverse.take(route_limit)
       end
 
+      [train_routes, path_walk_timed_out]
+    end
+
+    def compute_for_train_group(trains, corporation, **opts)
+      route_timeout = opts[:route_timeout] || 10
+
+      train_routes, path_walk_timed_out = path(trains, corporation, **opts)
       sorted_routes = train_routes.map { |_train, routes| routes }
 
       limit = sorted_routes.map(&:size).reduce(&:*)
@@ -451,6 +508,197 @@ module Engine
           }
         }
         return false
+      }
+
+      function estimate_revenue(router, routes, routes_metadata) {
+        // This is just a quick example of optimizations we can apply here.
+        // Calling back into ruby is expensive, so we try to estimate in js the
+        // upper bound of revenue and if the combo of routes are valid.
+
+        // This is just the "routes can't overlap" optimization using an opt
+        // out. An opt in would probably be safer, but the old autorouter always
+        // assumes it's valid, so this is no worse. Once we figure out how to configure
+        // the auto router per game, we should change this.
+
+        const opt_fails_overlap = {
+          1822: true,
+          1860: true,
+          1862: true,
+          "18 Los Angeles 2": true,
+        };
+        if (!opt_fails_overlap[router.title] && routes_metadata.overlap) {
+          return -1;
+        }
+        return routes_metadata.estimate_revenue;
+      }
+
+
+      function is_worth_adding_trains(router, routes, routes_metadata, next_routes) {
+        // TODO: I wonder if it's always true that revenue is less than
+        // or equal to the sum of the revenues of trains individually
+        return (
+          routes_metadata.estimate_revenue +
+            next_routes.max_possible_revenue_for_rest_of_trains >
+            router.best_revenue_so_far
+        );
+      }
+
+      function add_train_to_routes_metadata(
+        selected_routes,
+        route,
+        selected_routes_metadata,
+      ) {
+        return {
+          estimate_revenue:
+            selected_routes_metadata.estimate_revenue + route.estimate_revenue,
+          bitfield: js_route_bitfield_merge(
+            route.bitfield,
+            selected_routes_metadata.bitfield,
+          ),
+          overlap:
+            selected_routes_metadata.overlap ||
+            new_js_route_bitfield_conflicts(
+              route.bitfield,
+              selected_routes_metadata.bitfield,
+            ),
+        };
+      }
+
+      function get_empty_metadata() {
+        return {
+          estimate_revenue: 0,
+          bitfield: [],
+          overlap: false,
+        };
+      }
+
+      let start_of_execution_tick = 0;
+      let start_of_all = 0;
+      function next_frame() {
+        return new Promise(resolve => requestAnimationFrame(resolve));
+      }
+
+
+      async function new_autoroute(router, trains_to_routes_map) {
+        start_of_all = start_of_execution_tick = performance.now();
+        router.title = router.game.$meta().$title();
+        router.best_revenue_so_far = 0; // the best revenue we have found for a valid set of trains
+        router.best_routes = []; // the best set of routes
+        let trains_to_routes = Array.from(trains_to_routes_map).map(
+          ([train, routes]) => routes,
+        );
+
+        for (let i = 0; i < trains_to_routes.length; ++i) {
+          for (let j = 0; j < trains_to_routes[i].length; ++j) {
+            trains_to_routes[i][j].estimate_revenue = trains_to_routes[i][j].revenue;
+          }
+        }
+        let next_routes = null;
+        trains_to_routes.forEach((routes) => {
+          let r = next_routes
+            ? next_routes.max_possible_revenue_for_rest_of_trains
+            : 0;
+          r += routes[0].estimate_revenue;
+          next_routes = {
+            routes,
+            max_possible_revenue_for_rest_of_trains: r,
+            next: next_routes,
+          };
+        });
+        await find_best_combo(router, [], get_empty_metadata(), next_routes);
+
+        return router.best_routes;
+      }
+
+      // selected_routes : [Route] -- the subset of trains we are exploring and will expand on
+      // selected_routes_metadata : a bag of information to make searching faster. Example things: revenue of selected routes and bitset of trains routes
+      // next_routes : ?{ routes: [Route], max_possible_revenue_for_rest_of_trains: int,  next: NextRoutes}. This is basically a recursive data structure where we have a layer per train
+      async function find_best_combo(
+        router,
+        selected_routes,
+        selected_routes_metadata,
+        next_routes,
+      ) {
+        for (let route of next_routes.routes) {
+          if (performance.now() - start_of_execution_tick > 30) {
+            if (router.render) {
+                router.$real_revenue(router.best_routes)
+                g_update(router.best_routes)
+            }
+            await next_frame();
+            if (!router.running) {
+              return;
+            }
+            start_of_execution_tick = performance.now();
+          }
+          let current_routes_metadata = add_train_to_routes_metadata(
+            selected_routes,
+            route,
+            selected_routes_metadata,
+          );
+          // TODO: We probably will want to avoid the array copy for performance, but this is easier to understand for now
+          let current_routes = [...selected_routes, route];
+
+          // check if this new subset is the new best route
+          let estimate = estimate_revenue(router, current_routes, current_routes_metadata);
+          if (estimate > router.best_revenue_so_far) {
+            let revenue = router.$real_revenue(current_routes);
+            if (revenue > router.best_revenue_so_far) {
+              router.best_revenue_so_far = revenue;
+              router.best_routes = current_routes.map((r) => r.$clone());
+              router.render = true;
+            }
+          }
+
+          // if we have more routes to check
+          if (next_routes.next !== null) {
+          // first check without this train, so we don't get
+            // stuck with duplicate routes with 100% overlap on 1862 type maps as the suggested routes
+            await find_best_combo(
+              router,
+              selected_routes,
+              selected_routes_metadata,
+              next_routes.next,
+            );
+
+            // if we have another train to search for routes, check if it's worth exploring and if so, explore!
+            if (
+              is_worth_adding_trains(
+                router,
+                current_routes,
+                current_routes_metadata,
+                next_routes.next,
+              )
+            ) {
+              await find_best_combo(
+                router,
+                current_routes,
+                current_routes_metadata,
+                next_routes.next,
+              );
+            } else if (next_routes.next != null) {
+              console.log("skipping");
+            }
+          }
+        }
+      }
+
+      function new_js_route_bitfield_conflicts(a, b) {
+        let index = Math.min(a.length, b.length) - 1;
+        while (index >= 0) {
+          if ((a[index] & b[index]) != 0) return true;
+          index -= 1;
+        }
+        return false;
+      }
+
+      function js_route_bitfield_merge(a, b) {
+        let max = Math.max(a.length, b.length);
+        let result = [];
+        for (let i = 0; i < max; ++i) {
+          result.push((a[i] ?? 0) | (b[i] ?? 0));
+        }
+        return result;
       }
     }
   end

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -1511,11 +1511,6 @@ module Engine
         # - route intersection requirement
         # - freight track end-to-end requirements
         def check_overlap(routes)
-          return if routes.empty?
-
-          check_home_token(current_entity, routes)
-          check_intersection(routes)
-          check_freight_intersections(routes)
         end
 
         # This checks track reuse within a route
@@ -1592,6 +1587,11 @@ module Engine
 
         def check_other(route)
           check_overlap_single(route)
+          return if route.routes.empty?
+
+          check_home_token(current_entity, route.routes)
+          check_intersection(route.routes)
+          check_freight_intersections(route.routes)
         end
 
         def stop_on_other_route?(this_route, stop)

--- a/load_checker.js
+++ b/load_checker.js
@@ -1,0 +1,39 @@
+const fs = require('node:fs');
+const process = require('node:process');
+
+snabbdom = {
+    init: function() {}
+}
+
+Big = require('./public/assets/server.js').Big
+
+game_data_str = fs.readFileSync(process.argv[2], 'utf8')
+game_data = JSON.parse(game_data_str)
+if (game_data["error"]) return;
+
+
+title = game_data["title"]
+get_games_to_load(title)
+
+Opal.Engine.Logger.$set_level(null, true)
+
+if (process.env.VERBOSE) {
+      game = Opal.Engine.Game.$load(game_data_str)
+} else {
+   try{
+      game = Opal.Engine.Game.$load(game_data_str)
+   } catch ($e) {
+     console.log("failed to load:", process.argv[2])
+   }
+}
+
+// TODO: create a paths checker that makes sure all in gamedata paths are found by the autorouter
+
+function get_games_to_load(title) {
+  if (!title) return []
+  game_meta = Opal.Engine.$meta_by_title(title)
+console.log("loading", game_meta.$fs_name())
+  Opal.top.$require_tree("engine/game/"+game_meta.$fs_name())
+  Opal.top.$require("engine/game/"+game_meta.$fs_name())
+  get_games_to_load(game_meta.DEPENDS_ON)
+}

--- a/main.js
+++ b/main.js
@@ -1,0 +1,42 @@
+const fs = require('node:fs');
+
+Big = function () {}
+snabbdom = {
+    init: function() {}
+}
+
+Big = require('./public/assets/deps.js').Big
+require('./public/assets/main.js')
+
+game_data_str = fs.readFileSync('.game-corpus/137909.json', 'utf8')
+game_data = JSON.parse(game_data_str)
+
+title = game_data["title"]
+game_meta = Opal.Engine.$meta_by_title(title)
+title = game_meta.$fs_name()
+
+console.log(title)
+require('./public/assets/'+title+'.js')
+Opal.top.$require_tree("engine/game/"+title)
+Opal.top.$require("engine/game/"+title)
+// TODO ::DEPENDS_ON
+
+Opal.Engine.Logger.$set_level(null, true)
+
+for (let action of game_data["actions"]) {
+  if (action["type"] != "run_routes") continue;
+  console.log("exploring id:", action["id"])
+  game = Opal.Engine.Game.$load(game_data_str, new Map([["at_action", action["id"] - 1]]))
+  router = Opal.Engine.AutoRouter.$new(game, null)
+  let routes = router.$compute(game.$current_entity(), new Map([['routes', []]]))
+
+  try {
+     revenue = game.$routes_revenue(routes)
+  } catch ($e) {
+     revenue = "DNF";
+  }
+  console.log({revenue, hexside_bits: router.next_hexside_bit})
+}
+
+// TODO: create a paths checker that makes sure all in gamedata paths are found by the autorouter
+

--- a/minimal_corpus_finder.js
+++ b/minimal_corpus_finder.js
@@ -1,0 +1,39 @@
+const fs = require('node:fs');
+const process = require('node:process');
+
+snabbdom = {
+    init: function() {}
+}
+
+Big = require('./public/assets/server.js').Big
+
+let games_to_meta = {}
+Opal.Engine.GAME_META_BY_TITLE.forEach((meta, title) => games_to_meta[title] = {
+  stage: meta.$const_get('DEV_STAGE'),
+  count: 0,
+})
+
+let chosen_games = []
+for (let game_file of process.argv.slice(2)) {
+    let game_data_str = fs.readFileSync(game_file, 'utf8')
+    let game_data;
+    try {
+      game_data = JSON.parse(game_data_str)
+    } catch (e) {
+      continue;
+    }
+    if (game_data["error"]) continue;
+    if (games_to_meta[game_data["title"]].stage != "production") { continue};
+    if (games_to_meta[game_data["title"]].count > 3) { continue; }
+    if (game_data["actions"].reduce((total,x) => (x["type"] == "run_routes" ? total+1 : total), 0) < 15) { continue; }
+    chosen_games.push(game_file);
+    games_to_meta[game_data["title"]].count += 1;
+}
+
+for (const [title, d] of Object.entries(games_to_meta)) {
+  if (d.stage == "production" && d.count < 3) {
+    console.log("Missing some for", title, d.count)
+  }
+}
+
+process.stdout.write(chosen_games.join(" "))

--- a/new_analyze.js
+++ b/new_analyze.js
@@ -1,0 +1,111 @@
+const fs = require('node:fs');
+
+snabbdom = {
+    init: function() {}
+}
+
+Big = require('./public/assets/server.js').Big
+
+let games_times = {}
+games = {}
+game_id_to_title = {}
+buggy = {}
+opt_fails_overlap = {}
+opt_fails_invalid_combo_became_valid = {}
+
+
+let output = JSON.parse(fs.readFileSync('output.json', 'utf8'))
+let new_output = JSON.parse(fs.readFileSync('output.opt_flags.json', 'utf8'))
+
+for (let game_file of process.argv.slice(2)) {
+    let game_data_str = fs.readFileSync(game_file, 'utf8')
+    let game_data;
+    try {
+      game_data = JSON.parse(game_data_str)
+    } catch (e) {
+      console.log("failed to parse", game_file);
+      continue;
+    }
+    if (game_data["error"]) continue;
+
+    let title = game_data["title"]
+    if (!games[title]) {
+        games[title] = {
+          new_win: 0,
+          new_lose: 0,
+          equal: 0,
+          new_time: 0,
+          old_time: 0,
+          total_runs: 0,
+        }
+    }
+
+    for (let action of game_data["actions"]) {
+        let ids = game_data["id"]+':'+action["id"];
+        if (action["type"] != "run_routes") continue;
+        if (!output[ids]) continue;
+        if (!new_output[ids]) continue;
+        if (output[ids].revenue == "UNDO" ||
+new_output[ids].revenue == "UNDO"
+        ) {
+          if (new_output[ids].revenue != output[ids].revenue) {
+            console.log("undos unsynced", ids)
+            //throw "undo is unsynced";
+          }
+          continue;
+        }
+        let new_rev = new_output[ids].revenue
+        let old_rev = output[ids].revenue
+
+        // bail if one of the runs didn't finish
+        if ((new Set([old_rev, new_rev]).intersection(new Set(["DNF", "DNR"]))).size != 0) continue;
+
+        if (typeof new_rev !== 'number' || typeof old_rev !== 'number') {
+          console.log(new_rev, old_rev);
+          throw 'we got invalid revs';
+        }
+        if (new_rev > old_rev) {
+            games[title].new_win += 1
+        } else if (new_rev == old_rev) {
+            games[title].equal += 1
+        } else {
+            console.log(ids);
+            games[title].new_lose += 1
+        }
+
+        if (new_output[ids].time_seconds > 20) {
+          if(title=="1846") console.log("slowid", ids)
+        games_times[title] ??= {new:0, old:0}
+            games_times[title].new += 1;
+        }
+        if (output[ids].time_seconds > 20) {
+        games_times[title] ??= {new:0, old:0}
+            games_times[title].old += 1;
+        }
+
+        if (new_output[ids].OPT_FAIL_overlap) {
+            opt_fails_overlap[title] = true
+        }
+        if (new_output[ids].OPT_FAIL_invalid_combo_became_valid) {
+            if (title == "1846") console.log("this is the weird id", ids);
+            opt_fails_invalid_combo_became_valid[title] = true
+        }
+        if (new_output[ids].BUG_revenue_bigger_than_estimate) {
+            buggy[title] = true
+        }
+    }
+}
+
+console.log(games)
+
+console.log("new autorouter is good enough", Object.entries(games).filter((x) => x[1].new_lose == 0).map((x) => x[0]))
+console.log("new autorouter isn't good enough", Object.entries(games).filter((x) => x[1].new_lose != 0).map((x) => x[0]))
+
+console.log("new autorouter is better", Object.entries(games).filter((x) => x[1].new_win != 0).map((x) => x[0]))
+console.log("new autorouter isn't better", Object.entries(games).filter((x) => x[1].new_win == 0).map((x) => x[0]))
+
+console.log("buggy", buggy);
+console.log("opt_fails_overlap", opt_fails_overlap);
+console.log("opt_fails_invalid_combo_became_valid", opt_fails_invalid_combo_became_valid);
+
+console.log("slow runs", games_times);

--- a/new_autorouter.mjs
+++ b/new_autorouter.mjs
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import process from 'node:process';
+import { execFile} from 'node:child_process';
+
+let output_file = 'output.new.json';
+
+let output = load_output(output_file);
+let count = 0;
+let number_running = 0;
+
+async function main() {
+  let target_count = process.argv.length - 2;
+  let current_count = 0;
+  for (let game_file of process.argv.slice(2)) {
+    await run(game_file);
+    current_count += 1;
+    console.log(current_count, target_count);
+  }
+}
+await main();
+while (number_running != 0) {
+  await sleep(100)
+}
+write_output(output_file);
+
+async function run(game_file) {
+    let game_data_str = fs.readFileSync(game_file, 'utf8')
+    let game_data = JSON.parse(game_data_str)
+    if (game_data["error"]) return;
+
+    for (let action of game_data["actions"]) {
+        if (action["type"] != "run_routes") continue;
+        if (output[game_data["id"]+':'+action["id"]]) continue;
+        while (number_running == 6) await sleep(100)
+        number_running += 1
+        execFile('node', ['./new_autorouter_single.js', game_file, action["id"] + ""], {
+            stdio: 'pipe',
+            timeout: 260*1000,
+
+            // Use utf8 encoding for stdio pipes
+            encoding: 'utf8',
+        }, (error, stdout, stderr) => {
+            number_running -= 1;
+            try {
+                output[game_data["id"]+':'+action["id"]] = JSON.parse(stdout.match(new RegExp('output:(.*)'))[1])
+            } catch (e) {
+                console.log("failed to run", game_data["id"]+':'+action["id"])
+                output[game_data["id"]+':'+action["id"]] = {revenue: "DNR"}
+            }
+            let number_keys = Object.keys(output).length;
+            if (count + 5 < number_keys) {
+              write_output(output_file);
+              count = number_keys;
+            }
+        })
+    }
+}
+
+function load_output(file) {
+    return JSON.parse(fs.readFileSync(file, 'utf8'))
+}
+
+function write_output(file) {
+    return fs.writeFileSync(file, JSON.stringify(output))
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/new_autorouter_single.js
+++ b/new_autorouter_single.js
@@ -1,0 +1,65 @@
+const fs = require('node:fs');
+const process = require('node:process');
+
+requestAnimationFrame = function(f) {
+  setImmediate(f)
+}
+snabbdom = {
+    init: function() {}
+}
+
+Big = require('./public/assets/server.js').Big
+
+game_data_str = fs.readFileSync(process.argv[2], 'utf8')
+game_data = JSON.parse(game_data_str)
+if (game_data["error"]) return;
+
+title = game_data["title"]
+get_games_to_load(title)
+
+
+let target_action = process.argv[3];
+game = Opal.Engine.Game.$load(game_data_str, new Map([["at_action", target_action - 1]]))
+
+let filtered_actions = game.filtered_actions
+if (!filtered_actions.find((a) => { if (a instanceof Map) { return a.get("id") == target_action}})) {
+    process.stdout.write("output:"+JSON.stringify({revenue: "UNDO"})+"\n")
+    return
+}
+
+router = Opal.Engine.AutoRouter.$new(game)
+let start  = process.hrtime()
+let routes = null;
+router.$compute_new(game.$current_entity(), new Map([
+    ['routes', []],
+    ["path_timeout", 100],
+    ["route_timeout", 100],
+    ["route_limit", 100000],
+    ["callback", (routes_) => routes = routes_],
+    ["update", () => {}],
+]))
+require('node:timers').setInterval(() => {
+   if (!routes) return;
+   routes.forEach((route) => route["$clear_cache!"](new Map([["only_routes", true]])))
+   revenue = game.$routes_revenue(routes)
+   time = process.hrtime(start)
+   routes.forEach((route) => console.log(route.$revenue_str()));
+
+   process.stdout.write("output:"+JSON.stringify({
+     revenue,
+     real_revenue_call_count: router.real_revenue_call_count,
+     hexside_bits: router.next_hexside_bit,
+     max_memory: process.resourceUsage().maxRSS,
+     time_seconds: time[0],
+     ...router.analytics,
+   })+"\n")
+   process.exit(0);
+})
+
+function get_games_to_load(title) {
+  if (!title) return []
+  game_meta = Opal.Engine.$meta_by_title(title)
+  Opal.top.$require_tree("engine/game/"+game_meta.$fs_name())
+  Opal.top.$require("engine/game/"+game_meta.$fs_name())
+  get_games_to_load(game_meta.DEPENDS_ON)
+}

--- a/path_detector.js
+++ b/path_detector.js
@@ -1,0 +1,128 @@
+const fs = require('node:fs');
+const process = require('node:process');
+
+requestAnimationFrame = function(f) {
+  setImmediate(f)
+}
+snabbdom = {
+    init: function() {}
+}
+
+Big = require('./public/assets/server.js').Big
+
+game_data_str = fs.readFileSync(process.argv[2], 'utf8')
+game_data = JSON.parse(game_data_str)
+if (game_data["error"]) return;
+
+title = game_data["title"]
+get_games_to_load(title)
+
+
+let target_action = process.argv[3];
+game = Opal.Engine.Game.$load(game_data_str, new Map([["at_action", target_action - 1]]))
+
+let filtered_actions = game.filtered_actions
+if (!filtered_actions.find((a) => { if (a instanceof Map) { return a.get("id") == target_action}})) {
+    process.stdout.write("output:"+JSON.stringify({revenue: "UNDO"})+"\n")
+    return
+}
+
+router = Opal.Engine.AutoRouter.$new(game)
+let start  = process.hrtime()
+let routes = null;
+let desired_routes = get_desired_data(game_data);
+let max_route_walk = new Map(desired_routes.entries().map(([k,v]) => [k, []]))
+let max_route_valid_route = new Map(desired_routes.entries().map(([k,v]) => [k, []]))
+router.$compute_new(game.$current_entity(), new Map([
+    ['routes', []],
+    ["path_timeout", 100],
+    ["route_timeout", 0],
+    ["route_limit", 1],
+    ["callback", (routes_) => routes = routes_],
+    ["update", () => {}],
+    ["path_debugger", path_debugger],
+]))
+require('node:timers').setInterval(() => {
+   if (!routes) return;
+   routes.forEach((route) => route["$clear_cache!"](new Map([["only_routes", true]])))
+   revenue = game.$routes_revenue(routes)
+   time = process.hrtime(start)
+   routes.forEach((route) => console.log(route.$revenue_str()));
+
+   process.stdout.write("output:"+JSON.stringify({
+     revenue,
+     real_revenue_call_count: router.real_revenue_call_count,
+     hexside_bits: router.next_hexside_bit,
+     max_memory: process.resourceUsage().maxRSS,
+     time_seconds: time[0],
+     ...router.analytics,
+   })+"\n")
+  console.log(desired_routes, max_route_walk, max_route_valid_route)
+   if ([...desired_routes.keys()].every((k) => array_equal(max_route_walk.get(k), desired_routes.get(k)) || array_reverse_equal(max_route_walk.get(k), desired_routes.get(k))) && desired_routes.size == max_route_walk.size) {
+     console.log("walk:SUCCESS");
+   } else {
+     console.log("walk:FAIL");
+   }
+   if ([...desired_routes.keys()].every((k) => array_equal(max_route_valid_route.get(k), desired_routes.get(k)) || array_reverse_equal(max_route_valid_route.get(k), desired_routes.get(k))) && desired_routes.size == max_route_valid_route.size) {
+     console.log("valid_route:SUCCESS");
+   } else {
+     console.log("valid_route:FAIL");
+   }
+   process.exit(0);
+})
+
+function array_reverse_equal(a, b) {
+  return a.length == b.length && a.every((v, i) => v == b[b.length-i-1]);
+}
+
+function array_equal(a, b) {
+  return a.length == b.length && a.every((v, i) => v == b[i]);
+}
+
+function get_desired_data(game) {
+  let action = game["actions"].filter((a) => a["id"] == target_action)[0];
+  console.assert(action["type"] == "run_routes", "Action must be run_routes");
+  return new Map(action["routes"].map((r) => [r["train"], r["hexes"]]));
+}
+
+function get_games_to_load(title) {
+  if (!title) return []
+  game_meta = Opal.Engine.$meta_by_title(title)
+  Opal.top.$require_tree("engine/game/"+game_meta.$fs_name())
+  Opal.top.$require("engine/game/"+game_meta.$fs_name())
+  get_games_to_load(game_meta.DEPENDS_ON)
+}
+
+
+function array_starts_with(a, b) {
+  if (!a || !b) return false;
+  return a.length >= b.length && b.every((v, i) => v == a[i]);
+}
+
+function reverse_array_starts_with(a, b) {
+  if (!a || !b) return false;
+  return a.length >= b.length && b.every((v, i) => v == a[a.length-i-1]);
+}
+
+function path_debugger(state, route) {
+  let name = route.$train().$id()
+  let route_hexes = route.$hexes().$to_a().map((h) => h.$id().$to_s());
+  let desired_hexes = desired_routes.get(name);
+
+  // check if desired_hexes starts with route hexes
+  if (array_starts_with(desired_hexes, route_hexes) || reverse_array_starts_with(desired_hexes, route_hexes)) {
+    if (state == "walk") {
+      if (max_route_walk.get(name).length < route_hexes.length) {
+        max_route_walk.set(name, route_hexes)
+      }
+    } else if (state == "valid_route") {
+      if (max_route_valid_route.get(name).length < route_hexes.length) {
+        max_route_valid_route.set(name, route_hexes)
+      }
+    } else {
+      console.assert(false, "Unknown state");
+    }
+    return true;
+  }
+  return false;
+}

--- a/path_detector_loop.mjs
+++ b/path_detector_loop.mjs
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+import process from 'node:process';
+import { execFile} from 'node:child_process';
+import { DatabaseSync } from 'node:sqlite';
+const database = new DatabaseSync('output.db');
+
+database.exec(`
+  CREATE TABLE IF NOT EXISTS data(
+    game_id INTEGER,
+    action_id INTEGER,
+    title TEXT,
+    walk TEXT,
+    valid_route TEXT,
+    output TEXT,
+    error TEXT
+  ) STRICT
+`);
+
+const insert = database.prepare('INSERT INTO data VALUES (?, ?, ?, ?, ?, ?, ?)');
+const exists = database.prepare('SELECT 1 FROM data WHERE game_id = ? AND action_id = ?')
+
+
+let count = 0;
+let number_running = 0;
+
+async function main() {
+  let target_count = process.argv.length - 2;
+  let current_count = 0;
+  for (let game_file of process.argv.slice(2)) {
+    await run(game_file);
+    current_count += 1;
+    console.error(current_count, target_count);
+  }
+}
+await main();
+while (number_running != 0) {
+  await sleep(100)
+}
+
+async function run(game_file) {
+    let game_data_str = fs.readFileSync(game_file, 'utf8')
+    let game_data = JSON.parse(game_data_str)
+    if (game_data["error"]) return;
+
+    for (let action of game_data["actions"]) {
+        if (action["type"] != "run_routes") continue;
+        if (exists.get(game_data["id"], action["id"])) {
+          console.log("skipping", game_data["id"], action["id"])
+          continue;
+        }
+        while (number_running == 2) await sleep(100)
+        console.log("running", game_data["id"], action["id"])
+        number_running += 1
+        execFile('node', ['./path_detector.js', game_file, action["id"] + ""], {
+            stdio: 'pipe',
+            // todo: using this makes it so we can't detect what happened timeout: 0,
+
+            // Use utf8 encoding for stdio pipes
+            encoding: 'utf8',
+        }, (error, stdout, stderr) => {
+            number_running -= 1;
+            try {
+                let output = stdout.match(new RegExp('output:(.*)'))[1]
+                let valid_route = "unknown";
+                if (stdout.includes("valid_route:")) {
+                  valid_route = stdout.match(new RegExp('valid_route:(.*)'))[1]
+                }
+                let walk = "unknown";
+                if (stdout.includes("walk:")) {
+                  walk = stdout.match(new RegExp('walk:(.*)'))[1]
+                }
+                insert.run(game_data["id"], action["id"], game_data["title"], walk, valid_route, output, null);
+            } catch (e) {
+                insert.run(game_data["id"], action["id"], game_data["title"], "unknown", "unknown", "{}", e.toString());
+            }
+        })
+    }
+}
+
+function load_output(file) {
+    return JSON.parse(fs.readFileSync(file, 'utf8'))
+}
+
+function write_output(file) {
+    return fs.writeFileSync(file, JSON.stringify(output))
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}


### PR DESCRIPTION
I have been working on the autorouter on a private server for a while and was hoping to share my notes and hopefully merge some improvements.

# tl;dr

I made the autorouter work with 1862 and generally made some improvements to the router phase so it is more flexible to games with more complex routing + revenue rules.

- [Two](https://github.com/PistonPercy/18xx/commit/cf49e63d9ee0414ae31696a3d24b2d80af0b0daa) [patches](https://github.com/PistonPercy/18xx/commit/9b4ad8f6bb95043a2fc39b85dfc98e2bc6db3ad4) to fix pathing in 1862
- [A patch](https://github.com/PistonPercy/18xx/commit/aed4cff51507a5e82078c1633318c46c765311ef) to change routing to a simpler but more correct algorithm. It enables the autorouter to function for games that revenue can't be calculated per route independently and games that allow reusing tracks between different trains. 1862 is the easiest example of both. I expect this will require some refinement before being committed. I currently add a new button to choose which routing code to use, it's debatable if that's good for rollout (but was useful in early testing). I also think that having a `get_routing_rules` function on `Game` would be nice so we can avoid special casing titles in the autorouter and gives us a good place to expose this information in a declarative way (for what it is worth, as a user, I wish the game UI would expose the routing rules like they usually expose the market rules)
- [A fix](https://github.com/PistonPercy/18xx/commit/b56c2724cc8e5950a5ef05ff93641a61414d34aa) to the path generation because the new autorouter would generate routesets that the old autorouter never could.
- [A really bad](https://github.com/PistonPercy/18xx/commit/bc6e3774ec894f278cbff1eff3bf6aa142bc22d0) tool to test the autorouter using nodejs. A [less bad, but still wip](https://github.com/PistonPercy/18xx/commit/2ed823f3b5fb4cb90b57eed5d7d0cbbe5b228162) debugger for finding games where the game had paths that the pathing couldn't generate. Neither of these are mergable as is, but I'm sharing them to explore if a benchmarking/mass replay suite is useful. 


# Background on autorouter

The main parts of the autorouter are:
- pathing: finding all the valid routes for the trains
- routing: finding the combo of valid routes which are valid together that give the maximum value.

# Pathing

The primary source of bugs here are a mismatch of `check_other` expectations. As I understand `check_other` is only separate because the autorouter suppresses it in path generation. It is used to suppress rule checks for rules that require the full set of routes to validate.

As an example of rule that is suppose to be in `check_other`, in 1862, a route must visit the home token, but every path doesn't require visiting the home token. If that check isn't in check_other (which [it isn't](https://github.com/tobymao/18xx/blob/master/lib/engine/game/g_1862/game.rb#L1516)), we can only generate paths that visit the home token. Thus it is proper for the home token rule to be in `check_other`.

I'd also propose to rename `check_other` to `check_full_route_set` (or something better).

Other minor bugs:
- In 1860, a single train is able to go through a tokened out city, but the autorouter isn't able to generate routes going through tokened out cities because the [`blocks?`](https://github.com/tobymao/18xx/blob/68fd2453b54b00a1bc136fb9ba18470236f08931/lib/engine/part/city.rb#L37) will return true for tokened out city so the [graph walker](https://github.com/tobymao/18xx/blob/68fd2453b54b00a1bc136fb9ba18470236f08931/lib/engine/part/node.rb#L82) can't ever go through it

# Routing

## Current Algorithm

This is a bit of a high level view of the algorithm, but helps understand what it is doing.

1. Find all possible paths per train
2. Then call js_evaluate_combos which does
    1. Add the first train’s paths to a combo array
    2. For each train, for each route of that train
        1. for each combo in the combo array,
            1. js_route_bitfield_conflicts: Check if the route overlaps with the combo, if so continue the loop
            2. is_valid_combo: Check if the combo + route is a valid combo, if not, continue the loop
            3. Make newcombo with combo+route and calculate it’s revenue as combo.revenue + route.revenue
            4. Add newcombo to the new_combos array
            5. If newcombo revenue is more than the currently known most revenue, then add it to possibilities and set max_revenue
            6. If newcombo revenue is equal to the currently known most revenue, then add it to possibilities
        2. Set combo array to new_combos
3. Then we calculate the real revenue for each possibility and get return the possibility with the max revenue

## Problems/Bugs in Routing
- The combo and new_combo arrays scales with the number of valid paths and creates memory pressure and performance issues. I was actually getting out of memory issues in some testing.

- If `is_valid_combo` fails, then we toss out the combo even though adding a new train can make the combo valid in some variants (e.g. in 1862 adding a new train can make an invalid freight path valid)

- By using js_route_bitfield_conflicts, the auto router assumes routes must always use different tracks. This isn’t true in 1862 where different train can overlap on tracks.

- This algorithm assumes that a combo’s revenue is the sum of the routes revenues. This isn’t true in all variants (e.g. in 1862 where each city can only be counted once), so in these variants, the autorouter kind of returns a random variant. This can even kick in for games like 1846 (which has fairly basic rules) if you have the mail contract private company.

- The current autopather hangs the UI while pathing. This is frustrating for a variety of reasons, it means as users we can't just stop the router when it is "good enough" and the developer tools (like the profiler) are very difficult to use.

## Proposal To Fix Routing

I’d like propose to switch to a simpler, brute-force algorithm of checking all combinations of paths. I've been using this algorithm for a handful of games and it works pretty well.

The code is easily extended so that games can provide additional heuristics (mainly in "can this combinations of routes become the best set of routes if we add a train" and "estimate the upper bound of revenue of this set of routes"). I wish it wasn't worth doing this for some of the heavier maps/games, but the main problem is that calling ruby has some pretty severe performance traps (the main one I saw most often was returning from a lambda causes an exception to be thrown) and in general Opal seems to generate some expensive JS. It tends to be good enough in my experimentation without much customisation of the hooks, but I bet we could easily get an order of magnitude faster routing if we invested in better javascript only heuristics.

Some ideas of heuristic flags that games can provide:
- trains can't overlap (most games, but as an example 1862 can overlap tracks).
  This is actually implemented.
- trains must visit the home city (1860)
- [trains can visit a tokened out city once](http://www.fwtwr.com/18xx/rules_difference_list/7_2.htm)
- trains of different types can overlap (1822, 18 Los Angeles). This flag actually exists `TRAIN_AUTOROUTE_GROUPS`, but the new autorouter doesn't use it yet.
- train routes must intersect (1860)
- separating out single time per routeset revenue sources (E-W bonus + mail contract in 1846) so revenue estimate is more accurate

# Grab bag of other notes
- The autorouter being all in javascript embedded in ruby is rather difficult to work with.
- I found the fact that `Route` is mutable and depends on the route set that it is in extremely bug prone. It repeatedly bit me while working on these changes.
- The autorouter can faultily return a wrong revenue (it trips over the fact that a route's revenue is dependent on the routeset that it is in). This is this bug https://github.com/tobymao/18xx/issues/11078 also my stack of patches have a fix for it.
- I'll note that it would be nice if we extracted the autorouter into a js only file. This JS-embedded-in-ruby is annoying to deal with (syntax highligher doesn't work, no codeformat, no linters, etc)
